### PR TITLE
Fix: Updated to support empty items in the Wishlist page. 

### DIFF
--- a/analytics-snippets/WW_-_Account_-_GA-Event-Tracking.js
+++ b/analytics-snippets/WW_-_Account_-_GA-Event-Tracking.js
@@ -1,5 +1,4 @@
 $(function(){
-
   // Fire an event when the user logs in
   $('#dwfrm_login').submit(function(){
     ga(
@@ -9,7 +8,6 @@ $(function(){
       'Login'
     );
   });
-
   // Fire an event when the user registers on the /account page
    $('.registration_form_content #RegistrationForm').submit(function(){
     ga(
@@ -19,7 +17,6 @@ $(function(){
       'Register'
     );
   });
-
   // Track when user opts in to newsletter once logged in
   $('#edit-profile-btn').click(function(){
     setTimeout(function(){ // Set delay to wait for modal to appear
@@ -30,8 +27,6 @@ $(function(){
       });
     }, 1000);
   });
-
-
   // Track item removal from Wishlist
   $('body').on('click', '.saved-item-delete', function() {
     var removedProductSKU = $(this).parents().eq(2).find('input[name="pid"]').val().substring(0,8);
@@ -43,7 +38,6 @@ $(function(){
       removedProductSKU
     );
   });
-
   // Track item edit from wishlist
   $('body').on('click', '.quickviewbutton.edit_btn', function(){
     var editedItemCategory = $(this).parents('.product-tile').find('a.saved_item_image').attr('href').split('/')[5];
@@ -56,7 +50,6 @@ $(function(){
       editedItemSKU
     );
   });
-
   // When a user drags and drops items in their wishlist, fire an event. Wait until the window has loaded for jQuery Sortable to initialise. NEEDS WORK!
   $(window).load(function(){
     // Fire event by attaching the change listener to the jQuery UI Sortable plugin.
@@ -75,13 +68,11 @@ $(function(){
       }
     });
   });
-
   // Click to send Saved Items to a friend
   $('a#send-to-friend').click(function(){
     $('li.wishlist-item').each(function(){
       var wishlistItemSku = $(this).find('.product-tile').attr('data-itemid').substring(0,8);
       var wishlistItemCategory = $(this).find('.saved_item_image').attr('href').split('/')[5];
-
       ga(
         'send',
         'event',
@@ -91,14 +82,12 @@ $(function(){
       );
     });
   });
-
   /* When user adds an item from their Wishlist into their bag
      IMPORTANT: Note that it is possible to add an item to your wishlist without specifying a size if you do
     it from the PLP. We must therefore test to see if size is present in the DOM for this product. If there is a size,
     we must register a submit event straight away. If there is no size, we send a click event when the user clicks to select
     a size, and then send a submit event when the user adds the product to bag.
   */
-
   // This function will send a Submit event to GA when the product is submitted to bag. We create it as a function because it
   // can be called in two different scenarios - if the item has a size chosen for it, or if the item does not have a size chosen for it.
   function addToBagSubmitEvent(wishlistItemID, wishlistItemName, wishlistItemCategory) {
@@ -120,22 +109,23 @@ $(function(){
       clickedItemSKU
     );
   }
-
   /* Loop through the wishlist items and attach the appropriate click handlers, based on whether the item already has a size chosen or not.
      If the item has a size chosen, just attach a submit event handler.
      If the item doesn't have a size chosen, attach a click event handler and a submit event handler too.
   */
   $('li.wishlist-item').each(function(){
     var wishlistItemID = $(this).attr('id');
-    var wishlistItemName = $(this).find('.product-name a').text().trim();
-    var wishlistItemCategory = $(this).find('.product-name a').attr('href').split('/')[5]; // Get the category from the URL of the product's page.
 
-    // If the wishlist item has a size specified for it, we should just attach a submit event handler.
-    if ( $(this).find('.size').text().length > 0 ) {
-      console.log('item number ' + wishlistItemID + ' has a size specified.');
-      $(this).find('.product-action.add-to-cart').on('click', function(){
-        addToBagSubmitEvent(wishlistItemID, wishlistItemName, wishlistItemCategory);
-      });
+    if ($('.product-name a', this).length> 0) {
+      var wishlistItemName = $('.product-name a', this).text().trim();
+      var wishlistItemCategory = $('.product-name a', this).attr('href').split('/')[5]; // Get the category from the URL of the product's page.
+      // If the wishlist item has a size specified for it, we should just attach a submit event handler.
+      if ( $(this).find('.size').text().length > 0 ) {
+        // console.log('item number ' + wishlistItemID + ' has a size specified.');
+        $(this).find('.product-action.add-to-cart').on('click', function(){
+          addToBagSubmitEvent(wishlistItemID, wishlistItemName, wishlistItemCategory);
+        });
+      }
     }
     // If the wishlist item DOES NOT have a size specified for it, we attach a click event listener (to trigger the option for
     // the user to select a size and then a submit event listener for when the user adds the item to their bag.
@@ -144,7 +134,6 @@ $(function(){
       $(this).find('.product-action.add-to-cart:not(.action-addtocart)').on('click', function(){
         var clickedItemSKU = $('li#' + wishlistItemID).find('.saved_item_image > img').attr('src').split('/').pop().split('_')[1].split('.')[0];
         console.log(clickedItemSKU);
-
         // Now send in Submit event when size is selected and item added to bag.
         setTimeout(function(){ // Set a delay to allow time for the Add To Cart submit button to be shown.
           var refreshInterval = setInterval(function(){ // Set an interval timer to check to see if the Add To Cart button is disabled or not. It will be disabled if no size has been selected yet.
@@ -162,8 +151,6 @@ $(function(){
           }, 500);
         }, 1000);
       });
-
     }
   }); // End loop.
-
 });


### PR DESCRIPTION
Before it was throwing and error if you have empty items in your wishlist, causing the delete button to redirect on Firefox. 